### PR TITLE
09 js week days service

### DIFF
--- a/09-js-week-days-service/client.mjs
+++ b/09-js-week-days-service/client.mjs
@@ -1,0 +1,39 @@
+export default async function client(
+  year = new Date().getFullYear(),
+  month = new Date().getMonth() + 1,
+  day = new Date().getDate(),
+  flag = false,
+) {
+  const YEAR = Number(year) || (() => { throw new Error('Неверный формат года'); })();
+  const MONTH = Number(month) || (() => { throw new Error('Неверный формат месяца'); })();
+  const DAY = Number(day) || (() => { throw new Error('Неверный формат дня'); })();
+  const FLAG = (() => {
+    if (typeof flag === 'boolean') { return flag; }
+    if (flag === 'false') { return false; }
+    if (flag === 'true') { return true; }
+
+    throw new Error('Неверный формат флага');
+  })();
+  const body = JSON.stringify({
+    year: YEAR,
+    month: MONTH,
+    day: DAY,
+    flag: FLAG,
+  });
+  const res = await insteadOfFetch('./server.mjs', {
+    method: 'POST',
+    body,
+  });
+  const result = JSON.parse(res);
+
+  console.log(result);
+}
+
+async function insteadOfFetch(url, options) {
+  const obj = await import(url);
+  const code = obj.default;
+
+  return code(options);
+}
+
+client(process.argv[2], process.argv[3], process.argv[4], process.argv[5]).catch(console.log);

--- a/09-js-week-days-service/client.test.js
+++ b/09-js-week-days-service/client.test.js
@@ -1,0 +1,13 @@
+import client from './client.mjs';
+
+describe('Client function', () => {
+  test('should throw an error if parameters is invalid', async () => {
+    return expect(client('2021s', '12', '23', 'false')).rejects.toThrow();
+  });
+
+  test('should output its result to the console', async () => {
+    const spy = jest.spyOn(console, 'log');
+    await client('2021', '12', '23', 'false');
+    expect(spy).toHaveBeenCalledWith('четверг');
+  })
+});

--- a/09-js-week-days-service/server.mjs
+++ b/09-js-week-days-service/server.mjs
@@ -1,0 +1,11 @@
+export default function server(options) {
+  const {
+    year, month, day, flag,
+  } = JSON.parse(options.body);
+  const numberOfDay = new Date(year, month - 1, day).getDay();
+  const WEEK_DAY_SHORT_NAMES = ['вс', 'пн', 'вт', 'ср', 'чт', 'пт', 'сб'];
+  const WEEK_DAY_LONG_NAMES = ['воскресенье', 'понедельник', 'вторник', 'среда', 'четверг', 'пятница', 'суббота'];
+  const dayOfWeek = flag ? WEEK_DAY_SHORT_NAMES[numberOfDay] : WEEK_DAY_LONG_NAMES[numberOfDay];
+
+  return JSON.stringify(dayOfWeek);
+}

--- a/09-js-week-days-service/server.test.js
+++ b/09-js-week-days-service/server.test.js
@@ -1,0 +1,15 @@
+import server from './server.mjs';
+
+const mock1 = { method: 'POST', body: '{"year":2021,"month":12,"day":23,"flag":false}', };
+const mock2 = { method: 'POST', body: '{"year":2021,"month":12,"day":21,"flag":true}', };
+
+describe('Server function', () => {
+  test('should return valid JSON', () => {
+    expect(() => { JSON.parse(server(mock1)) }).not.toThrow();
+  });
+
+  test('should return correct value', () => {
+    expect(server(mock1)).toBe('"четверг"');
+    expect(server(mock2)).toBe('"вт"');
+  });
+});


### PR DESCRIPTION
Задача: Сервис дней недели

Написать 2 функции, эмулирующие работу клиент-сервер.

Функция для "клиента" принимает 3 числа (год, месяц, день) и флаг формата, запрашивает у "сервера" день недели для указанной даты и выводит результат в консоль браузера. Формат - необязательный параметр булевого типа: true означает запрос дня недели в сокращённом формате (пн-вс), false - в полном.

Функция для "сервера" принимает строку в формате JSON, содержащую данные по запрашиваемой дате и формату, производит вычисления и отдаёт "клиенту" JSON результат.